### PR TITLE
RSDK-6694 cross-compile x264

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ on:
 
 env:
   GOOS: android
+  GOARCH: arm64
   NDK_DIR: android-ndk-r26
   NDK_ZIP: android-ndk-r26-linux.zip
   # note: r26 won't always be 26.1.109xxx, use env vars for this and pin the DL

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "x264"]
+	path = x264
+	url = https://code.videolan.org/videolan/x264.git

--- a/Makefile
+++ b/Makefile
@@ -26,14 +26,13 @@ STRIP := $(TOOLCHAIN)/bin/llvm-strip
 NM := $(TOOLCHAIN)/bin/llvm-nm
 SYSROOT := $(TOOLCHAIN)/sysroot
 
-FFMPEG_SUBDIR=viamrtsp/ffmpeg-android
-FFMPEG_PREFIX=$(HOME)/$(FFMPEG_SUBDIR)
-X264_SUBDIR=viamrtsp/x264-android
+DROIDLIB_SUBDIR=viamrtsp-android
+DROIDLIB_PREFIX=$(HOME)/$(DROIDLIB_SUBDIR)
 
 # CGO settings
 CGO_ENABLED := 1
-CGO_CFLAGS := -I$(FFMPEG_PREFIX)/include
-CGO_LDFLAGS := -L$(FFMPEG_PREFIX)/lib
+CGO_CFLAGS := -I$(DROIDLIB_PREFIX)/include
+CGO_LDFLAGS := -L$(DROIDLIB_PREFIX)/lib
 OUTPUT_DIR := bin
 OUTPUT := $(OUTPUT_DIR)/viamrtsp-$(GOOS)-$(GOARCH)
 
@@ -61,7 +60,7 @@ build-android:
 
 module.tar.gz: $(OUTPUT) run.sh
 	# todo: dedup with 'make module' command
-	tar czf $@ $^ -C $(FFMPEG_PREFIX) lib
+	tar czf $@ $^ -C $(DROIDLIB_PREFIX) lib
 
 # Create linux AppImage bundle
 .PHONY: package
@@ -84,7 +83,7 @@ FFmpeg:
 x264-android:
 	# todo: pass -arch armv8-a in cflags
 	cd x264 && CC=$(CC) ./configure \
-		--prefix=$(HOME)/$(X264_SUBDIR) \
+		--prefix=$(DROIDLIB_PREFIX) \
 		--host=aarch64-linux-android \
 		--cross-prefix=$(TOOLCHAIN)/bin/llvm- \
 		--sysroot=$(SYSROOT) \
@@ -104,7 +103,7 @@ x264-android:
 ffmpeg-android: FFmpeg
 	cd FFmpeg && \
 	./configure \
-		--prefix=$(FFMPEG_PREFIX) \
+		--prefix=$(DROIDLIB_PREFIX) \
 		--target-os=android \
 		--arch=aarch64 \
 		--cpu=armv8-a \
@@ -130,7 +129,7 @@ ffmpeg-android: FFmpeg
 
 # Push FFmpeg to android device
 push-ffmpeg-android:
-	adb push $(FFMPEG_PREFIX) android /data/local/tmp/ffmpeg
+	adb push $(DROIDLIB_PREFIX) android /data/local/tmp/ffmpeg
 
 # Push binary to android device
 push-binary-android:

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ SYSROOT := $(TOOLCHAIN)/sysroot
 
 FFMPEG_SUBDIR=viamrtsp/ffmpeg-android
 FFMPEG_PREFIX=$(HOME)/$(FFMPEG_SUBDIR)
+X264_SUBDIR=viamrtsp/x264-android
 
 # CGO settings
 CGO_ENABLED := 1
@@ -79,6 +80,23 @@ FFmpeg:
 	# clone ffmpeg in the spot we need
 	# todo: maybe make this a submodule
 	git clone https://github.com/FFmpeg/FFmpeg -b n6.1.1 --depth 1
+
+x264-android:
+	# todo: pass -arch armv8-a in cflags
+	cd x264 && CC=$(CC) ./configure \
+		--prefix=$(HOME)/$(X264_SUBDIR) \
+		--host=aarch64-linux-android \
+		--cross-prefix=$(TOOLCHAIN)/bin/llvm- \
+		--sysroot=$(SYSROOT) \
+		--enable-shared \
+		--disable-avs \
+		--disable-swscale \
+		--disable-lavf \
+		--disable-ffms \
+		--disable-gpac \
+		--disable-lsmash \
+	&& make -j$(shell nproc) \
+	&& make install
 
 # Build FFmpeg for Android
 # Requires Android NDK to be installed


### PR DESCRIPTION
## What changed
- added x264 library as submodule, on its `stable` branch
  - we may want to make this manual rather than submodule -- non android users won't need this
- build command working on linux, :crossed_fingers: on :apple: too but pls test